### PR TITLE
fix: PLT-32250 make max buffer size configurable

### DIFF
--- a/src/Ratchet/Http/HttpRequestParser.php
+++ b/src/Ratchet/Http/HttpRequestParser.php
@@ -17,7 +17,14 @@ class HttpRequestParser implements MessageInterface {
      * This is a security measure to prevent attacks
      * @var int
      */
-    public $maxSize = 4096;
+    public $maxSize;
+
+    /**
+     * @param int $maxBufferSize
+     */
+    public function __construct($maxBufferSize = 4096) {
+        $this->maxSize = $maxBufferSize;
+    }
 
     /**
      * @param \Ratchet\ConnectionInterface $context

--- a/src/Ratchet/Http/HttpServer.php
+++ b/src/Ratchet/Http/HttpServer.php
@@ -18,11 +18,12 @@ class HttpServer implements MessageComponentInterface {
     protected $_httpServer;
 
     /**
-     * @param HttpServerInterface
+     * @param HttpServerInterface $component
+     * @param int $maxBufferSize
      */
-    public function __construct(HttpServerInterface $component) {
+    public function __construct(HttpServerInterface $component, $maxBufferSize = 4096) {
         $this->_httpServer = $component;
-        $this->_reqParser  = new HttpRequestParser;
+        $this->_reqParser  = new HttpRequestParser($maxBufferSize);
     }
 
     /**


### PR DESCRIPTION
Add the ability to configure the max buffer size, as the "tavern" app web socket cannot be open when there is a JWT payload in cookies (auth project).